### PR TITLE
Fixed issue with ouput files with fragments

### DIFF
--- a/projects/TruJS.compile/scripts/_FileObj.js
+++ b/projects/TruJS.compile/scripts/_FileObj.js
@@ -21,8 +21,8 @@ function _FileObj(nodePath) {
 
     if (!path.name) {
       path.name = !!path.base && nodePath.parse(path.base).name
-              || !!path.path && nodePath.parse(path.path).name
-              || path.name;
+              || !!path.file && nodePath.parse(path.file).name
+              || !!path.path && nodePath.parse(path.path).name;
     }
 
     if (!path.dir) {
@@ -31,7 +31,7 @@ function _FileObj(nodePath) {
     }
 
     //convert the path object to a file object
-    path.file = path.base || (path.name + path.ext);
+    path.file = path.file || path.base || (path.name + path.ext);
     path.path = path.path || nodePath.join(path.dir, path.file);
     delete path.base;
     path.data = data;

--- a/projects/TruJS.compile/scripts/_FileObj.spec.js
+++ b/projects/TruJS.compile/scripts/_FileObj.spec.js
@@ -36,7 +36,7 @@ function testFileObj1(arrange, act, assert, module) {
   });
 }
 
-/**[@test({ "title": "TruJS.compile._FileObj: path object and data" })]*/
+/**[@test({ "title": "TruJS.compile._FileObj: path object w/ file property and data" })]*/
 function testFileObj2(arrange, act, assert, module) {
   var fileObj, path, data, res, nodePath;
 
@@ -44,6 +44,8 @@ function testFileObj2(arrange, act, assert, module) {
     nodePath = module(".nodePath");
     fileObj = module(["TruJS.compile._FileObj", []]);
     path = nodePath.parse("/base/path/file.js");
+    path.file = path.base;
+    delete path.base;
     data = "file data";
   });
 

--- a/projects/TruJS.compile/scripts/_FilesSaver.spec.js
+++ b/projects/TruJS.compile/scripts/_FilesSaver.spec.js
@@ -30,7 +30,6 @@ function testFileSaver1(arrange, act, assert, module, callback) {
         done();
       })
       .catch(function (err) {
-        console.log(err);
         res = err;
         done();
       });
@@ -42,13 +41,13 @@ function testFileSaver1(arrange, act, assert, module, callback) {
       .not()
       .isError();
 
-    test("The mkdir callback should be called once")
+    test("The mkdir callback should be called 5 times")
       .value(nodeFs, "mkdir")
-      .hasBeenCalled(1);
+      .hasBeenCalled(5);
 
     test("The mkdir should be called with path")
       .value(nodeFs, "mkdir")
-      .hasBeenCalledWithArg(0, 0, mkdirPath);
+      .hasBeenCalledWithArg(4, 0, mkdirPath);
 
     test("The writeFile callback should be called once")
       .value(nodeFs, "writeFile")
@@ -147,7 +146,7 @@ function testFileSaver3(arrange, act, assert, module, callback) {
 
     test("The mkdir should be called with path")
       .value(nodeFs, "mkdir")
-      .hasBeenCalledWithArg(0, 0, mkdirPath);
+      .hasBeenCalledWithArg(4, 0, mkdirPath);
 
     test("The writeFile callback should be called with path")
       .value(nodeFs, "writeFile")

--- a/projects/TruJS.compile/scripts/_PathProcessor.js
+++ b/projects/TruJS.compile/scripts/_PathProcessor.js
@@ -75,7 +75,7 @@ function _PathProcessor(nodePath, pathParser) {
         pathObj.directory = true;
         pathObj.options.recurse = true;
         pathObj.fragment = pathObj.dir.substring(pathObj.dir.indexOf("*"));
-        pathObj.path = pathObj.dir.substring(0, pathObj.dir.indexOf("*"));
+        pathObj.path = pathObj.dir = pathObj.dir.substring(0, pathObj.dir.indexOf("*"));
     }
 
     return pathObj;

--- a/projects/TruJS.compile/scripts/_PathResultProcessor.js
+++ b/projects/TruJS.compile/scripts/_PathResultProcessor.js
@@ -14,12 +14,12 @@ function _PathResultProcessor(nodePath, regExGetMatches, stringTrim) {
     if (!!pathObj.wildcard || !!pathObj.fragment) {
 
       //add the path
-      var filter = "(" + updateReserved(!!pathObj.path && stringTrim(pathObj.path, "[\\/\\\\]", "end") || "*") + ")";
+      var filter = "(" + updateReserved(!!pathObj.path && stringTrim(pathObj.path, "[/\\\\]", "end") || "*") + ")";
       //add the fragment
       if (!!pathObj.fragment) {
-        filter = filter + "[/\\\\](" + updateReserved(pathObj.fragment) + ")";
+        filter = filter + "[/\\\\](" + updateReserved(pathObj.fragment) + (!!pathObj.options && !!pathObj.options.recurse && "(?:[/\\\\](.*))?" || "") + ")";
       }
-      else if (!!pathObj.options.recurse) {
+      else if (!!pathObj.options && !!pathObj.options.recurse) {
         filter = filter + "(?:[/\\\\](.*))?"; //allow all child paths
       }
       else if(pathObj.minus && !pathObj.path) {
@@ -184,6 +184,7 @@ function _PathResultProcessor(nodePath, regExGetMatches, stringTrim) {
     if (isObject(result)) {
       //get the matcher from the wildcard
       var matcher = getMatcher(result);
+
       if (result.minus) {
         procFiles = minusFiles(procFiles, result, matcher);
       }

--- a/projects/TruJS.compile/scripts/_PathResultProcessor.spec.js
+++ b/projects/TruJS.compile/scripts/_PathResultProcessor.spec.js
@@ -48,6 +48,8 @@ function testPathResultProcessor1(arrange, act, assert, module) {
     test("There should be 5 files")
       .value(files)
       .hasMemberCountOf(5);
+
+
     test("The files should be unique")
       .value(files)
       .isUnique();

--- a/projects/TruJS.compile/scripts/assembler/_JavaScriptAssembler.js
+++ b/projects/TruJS.compile/scripts/assembler/_JavaScriptAssembler.js
@@ -26,7 +26,7 @@
 *
 * @module
 */
-function _JavaScriptAssembler(promise, annotation, nodePath, stringTrim, getLineEnding, regExGetMatches, stringInsert, namer) {
+function _JavaScriptAssembler(promise, annotation, nodePath, stringTrim, getLineEnding, regExGetMatches, stringInsert, namer, fileObj) {
   var COMM_PATT = /^\s?((?:\/[*]{1,2}[\s\S]*?[*]\/\r?\n)|(?:[\/]{2}[^\n]*\n))+/g
   ;
 
@@ -39,7 +39,7 @@ function _JavaScriptAssembler(promise, annotation, nodePath, stringTrim, getLine
     var data = [] //array for the processed file data
     , namespaces = [] //array for required namespaces
     , lineEnding
-    , fileObj = nodePath.parse(entry.name + ".js") //the new file object with fake name
+    , pathObj = nodePath.parse(entry.name + ".js") //the new file object with fake name
     ;
 
     //loop through the file objects, process each, and add the result to the
@@ -53,11 +53,11 @@ function _JavaScriptAssembler(promise, annotation, nodePath, stringTrim, getLine
     //add the namespace entries
     data = addNamespaces(namespaces, data, lineEnding).concat(data);
 
-    //join the data array and update the new file object
-    fileObj.data = [data.join(lineEnding + lineEnding)];
+    //join the data array
+    data = [data.join(lineEnding + lineEnding)];
 
     //resolve with the file object
-    resolve([fileObj]);
+    resolve([fileObj(pathObj.base, data)]);
   }
   /**
   * Runs the namer and determines if the name should be added to the file data

--- a/projects/TruJS.compile/scripts/assembler/_JavaScriptAssembler.spec.js
+++ b/projects/TruJS.compile/scripts/assembler/_JavaScriptAssembler.spec.js
@@ -36,8 +36,8 @@ function testJavaScriptAssembler(arrange, act, assert, callback, module) {
       .value(res)
       .hasMemberCountOf(1);
 
-    test("res[0].base should be")
-      .value(res, "[0].base")
+    test("res[0].file should be")
+      .value(res, "[0].file")
       .equals("TestName.js");
 
     test("res[0].data[0] should be")

--- a/projects/TruJS.compile/scripts/collector/_CollectionCollector.js
+++ b/projects/TruJS.compile/scripts/collector/_CollectionCollector.js
@@ -16,7 +16,7 @@
 *
 * @factory
 */
-function _CollectionCollector(promise, nodeFs, pathResolver, getScriptsDir, errors) {
+function _CollectionCollector(promise, nodeFs, pathResolver, getScriptsDir, errors, fileObj) {
 
   /**
   * Resolves all relative paths in the entry's `files` array
@@ -59,7 +59,7 @@ function _CollectionCollector(promise, nodeFs, pathResolver, getScriptsDir, erro
     }
 
     //handler for the file read callback
-    function readFileCb(err, data, fileObj, indx) {
+    function readFileCb(err, data, pathObj, indx) {
       //stop if we've had an error
       if(hasErr) {
         return;
@@ -72,8 +72,8 @@ function _CollectionCollector(promise, nodeFs, pathResolver, getScriptsDir, erro
       }
       else {
         //add the data to the object and update the array
-        fileObj.data = data;
-        allData[indx] = fileObj;
+        //fileObj.data = data;
+        allData[indx] = fileObj(pathObj, data);
 
         len--;
         if (len === 0) {
@@ -105,7 +105,7 @@ function _CollectionCollector(promise, nodeFs, pathResolver, getScriptsDir, erro
         });
       }
       else {
-        return promise.resolve(paths);
+        return promise.resolve([]);
       }
     });
 


### PR DESCRIPTION
The fileObj was not using the file property when available. 
Various factories weren't using the fileObj when creating the file object.